### PR TITLE
Update license headers

### DIFF
--- a/examples/Client/Client.ino
+++ b/examples/Client/Client.ino
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
 #include <Arduino.h>
 #include <AsyncTCP.h>
 #include <WiFi.h>

--- a/idf_component_examples/client/main/main.cpp
+++ b/idf_component_examples/client/main/main.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
 #include "Arduino.h"
 #include "AsyncTCP.h"
 #include "WiFi.h"

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1,23 +1,5 @@
-/*
-  Asynchronous TCP library for Espressif MCUs
-
-  Copyright (c) 2016 Hristo Gochkov. All rights reserved.
-  This file is part of the esp8266 core for Arduino environment.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- */
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
 
 #include "Arduino.h"
 

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -1,23 +1,5 @@
-/*
-  Asynchronous TCP library for Espressif MCUs
-
-  Copyright (c) 2016 Hristo Gochkov. All rights reserved.
-  This file is part of the esp8266 core for Arduino environment.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
 
 #ifndef ASYNCTCP_H_
 #define ASYNCTCP_H_


### PR DESCRIPTION
(also same pr in espasyncws: https://github.com/ESP32Async/ESPAsyncWebServer/pull/15)

The project is under LGPL license so the source files should reflect that by having a license header compliant with LGPL, or at least have an appropriate SPDX header.

This changed is required to allow the source files to be used in downstream project because some files are not licensed in accordance to the LPGL rules.

Refs:

- https://www.gnu.org/licenses/gpl-howto.html
- https://spdx.dev/learn/handling-license-info/
- https://spdx.org/licenses/LGPL-3.0-or-later.html