### PR TITLE
Replace queue with linked list

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -765,14 +765,13 @@ bool AsyncClient::_connect(ip_addr_t addr, uint16_t port) {
   }
 
   TCP_MUTEX_LOCK();
-  tcp_pcb *pcb = tcp_new_ip_type(addr.type);
-  if (!pcb) {
+  _pcb = tcp_new_ip_type(addr.type);
+  if (!_pcb) {
     TCP_MUTEX_UNLOCK();
     log_e("pcb == NULL");
     return false;
   }
   _end_event = _register_pcb(_pcb, this);
-  TCP_MUTEX_UNLOCK();
 
   if (!_end_event) {
     log_e("Unable to allocate event");
@@ -780,6 +779,7 @@ bool AsyncClient::_connect(ip_addr_t addr, uint16_t port) {
     _pcb = nullptr;
     return false;
   }
+  TCP_MUTEX_UNLOCK();
 
   tcp_api_call_t msg;
   msg.pcb_ptr = &_pcb;

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -708,26 +708,6 @@ AsyncClient::~AsyncClient() {
  * Operators
  * */
 
-/* TODO
-AsyncClient& AsyncClient::operator=(const AsyncClient& other) {
-  if (_pcb) {
-    _close();
-  }
-
-  _pcb = other._pcb;
-  _closed_slot = other._closed_slot;
-  if (_pcb) {
-    _rx_last_packet = millis();
-    tcp_arg(_pcb, this);
-    tcp_recv(_pcb, &_tcp_recv);
-    tcp_sent(_pcb, &_tcp_sent);
-    tcp_err(_pcb, &_tcp_error);
-    tcp_poll(_pcb, &_tcp_poll, CONFIG_ASYNC_TCP_POLL_TIMER);
-  }
-  return *this;
-}
-*/
-
 bool AsyncClient::operator==(const AsyncClient &other) {
   return _pcb == other._pcb;
 }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -284,7 +284,7 @@ static lwip_tcp_event_packet_t *_register_pcb(tcp_pcb *pcb, AsyncClient *client)
     tcp_recv(pcb, &_tcp_recv);
     tcp_sent(pcb, &_tcp_sent);
     tcp_err(pcb, &_tcp_error);
-    tcp_poll(pcb, &_tcp_poll, 1);
+    tcp_poll(pcb, &_tcp_poll, CONFIG_ASYNC_TCP_POLL_TIMER);
   };
   return end_event;
 }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -679,12 +679,7 @@ static tcp_pcb *_tcp_listen_with_backlog(tcp_pcb *pcb, uint8_t backlog) {
 AsyncClient::AsyncClient(tcp_pcb *pcb)
   : _pcb(pcb), _end_event(nullptr), _connect_cb(0), _connect_cb_arg(0), _discard_cb(0), _discard_cb_arg(0), _sent_cb(0), _sent_cb_arg(0), _error_cb(0),
     _error_cb_arg(0), _recv_cb(0), _recv_cb_arg(0), _pb_cb(0), _pb_cb_arg(0), _timeout_cb(0), _timeout_cb_arg(0), _ack_pcb(true), _tx_last_packet(0),
-    _rx_timeout(0), _rx_last_ack(0), _ack_timeout(CONFIG_ASYNC_TCP_MAX_ACK_TIME), _connect_port(0)
-#ifdef CONFIG_ASYNC_TCP_CLIENT_LIST
-    ,
-    prev(NULL), next(NULL)
-#endif
-{
+    _rx_timeout(0), _rx_last_ack(0), _ack_timeout(CONFIG_ASYNC_TCP_MAX_ACK_TIME), _connect_port(0) {
   if (_pcb) {
     _end_event = _register_pcb(_pcb, this);
     _rx_last_packet = millis();
@@ -736,23 +731,6 @@ AsyncClient& AsyncClient::operator=(const AsyncClient& other) {
 bool AsyncClient::operator==(const AsyncClient &other) {
   return _pcb == other._pcb;
 }
-
-#ifdef CONFIG_ASYNC_TCP_CLIENT_LIST
-AsyncClient &AsyncClient::operator+=(const AsyncClient &other) {
-  if (next == NULL) {
-    next = (AsyncClient *)(&other);
-    next->prev = this;
-  } else {
-    AsyncClient *c = next;
-    while (c->next != NULL) {
-      c = c->next;
-    }
-    c->next = (AsyncClient *)(&other);
-    c->next->prev = c;
-  }
-  return *this;
-}
-#endif
 
 /*
  * Callback Setters

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1444,12 +1444,10 @@ void AsyncServer::end() {
     tcp_arg(_pcb, NULL);
     tcp_accept(_pcb, NULL);
     if (tcp_close(_pcb) != ERR_OK) {
-      TCP_MUTEX_UNLOCK();
       _tcp_abort(&_pcb);
-    } else {
-      TCP_MUTEX_UNLOCK();
     }
     _pcb = NULL;
+    TCP_MUTEX_UNLOCK();
   }
 }
 

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1465,12 +1465,6 @@ int8_t AsyncServer::_accept(tcp_pcb *pcb, int8_t err) {
           return ERR_OK;  // success
         }
       }
-      if (c->pcb()) {
-        // Couldn't allocate accept event
-        // We can't let the client object call in to close, as we're on the LWIP thread; it could deadlock trying to RPC to itself
-        AsyncClient_detail::invalidate_pcb(*c);
-        tcp_abort(pcb);
-      }
       if (c) {
         // Couldn't complete setup
         // pcb has already been aborted

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -286,25 +286,22 @@ inline lwip_tcp_event_packet_t *AsyncClient_detail::invalidate_pcb(AsyncClient &
 
 inline lwip_tcp_event_packet_t *AsyncClient_detail::get_async_event() {
   queue_mutex_guard guard;
-  lwip_tcp_event_packet_t *e = nullptr;
-  if (guard) {
-    e = _async_queue.pop_front();
-    // special case: override values
-    if (e) {
-      switch (e->event) {
-        case LWIP_TCP_RECV:
-          if ((e->recv.err == 0) && (e->recv.pb == nullptr)) {
-            e->recv.pb = e->client->_recv_pending;
-            e->client->_recv_pending = nullptr;
-          }
-          break;
-        case LWIP_TCP_SENT:
-          e->sent.len = e->client->_sent_pending;
-          e->client->_sent_pending = 0;
-          break;
-        case LWIP_TCP_POLL: e->client->_polls_pending = 0; break;
-        default:            break;
-      }
+  lwip_tcp_event_packet_t *e  = _async_queue.pop_front();
+  // special case: override values
+  if (e) {
+    switch (e->event) {
+      case LWIP_TCP_RECV:
+        if ((e->recv.err == 0) && (e->recv.pb == nullptr)) {
+          e->recv.pb = e->client->_recv_pending;
+          e->client->_recv_pending = nullptr;
+        }
+        break;
+      case LWIP_TCP_SENT:
+        e->sent.len = e->client->_sent_pending;
+        e->client->_sent_pending = 0;
+        break;
+      case LWIP_TCP_POLL: e->client->_polls_pending = 0; break;
+      default:            break;
     }
   }
   DEBUG_PRINTF("0x%08x", (intptr_t)e);

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -705,14 +705,6 @@ AsyncClient::~AsyncClient() {
 }
 
 /*
- * Operators
- * */
-
-bool AsyncClient::operator==(const AsyncClient &other) {
-  return _pcb == other._pcb;
-}
-
-/*
  * Callback Setters
  * */
 

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -536,7 +536,7 @@ typedef struct {
     } write;
     size_t received;
     struct {
-      ip_addr_t *addr;
+      const ip_addr_t *addr;
       uint16_t port;
       tcp_connected_fn cb;
     } connect;
@@ -634,6 +634,9 @@ static esp_err_t _tcp_abort(tcp_pcb **pcb_ptr) {
 
 static err_t _tcp_connect_api(struct tcpip_api_call_data *api_call_msg) {
   tcp_api_call_t *msg = (tcp_api_call_t *)api_call_msg;
+  Serial.printf("Attempting connection with PCB %08X, ", (intptr_t)*msg->pcb_ptr);
+  Serial.print(IPAddress(msg->connect.addr));
+  Serial.printf(", port %d\n", msg->connect.port);
   msg->err = tcp_connect(*msg->pcb_ptr, msg->connect.addr, msg->connect.port, msg->connect.cb);
   return msg->err;
 }
@@ -754,7 +757,7 @@ void AsyncClient::onPoll(AcConnectHandler cb, void *arg) {
  * Main Public Methods
  * */
 
-bool AsyncClient::_connect(ip_addr_t addr, uint16_t port) {
+bool AsyncClient::_connect(const ip_addr_t &addr, uint16_t port) {
   if (_pcb) {
     log_d("already connected, state %d", _pcb->state);
     return false;

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -164,7 +164,7 @@ class queue_mutex_guard {
   bool holds_mutex;
 
 public:
-  inline queue_mutex_guard() : holds_mutex(xSemaphoreTake(_async_queue_mutex, portMAX_DELAY)) {};
+  inline queue_mutex_guard() : holds_mutex(xSemaphoreTake(_async_queue_mutex, portMAX_DELAY)){};
   inline ~queue_mutex_guard() {
     if (holds_mutex) {
       xSemaphoreGive(_async_queue_mutex);

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -634,9 +634,6 @@ static esp_err_t _tcp_abort(tcp_pcb **pcb_ptr) {
 
 static err_t _tcp_connect_api(struct tcpip_api_call_data *api_call_msg) {
   tcp_api_call_t *msg = (tcp_api_call_t *)api_call_msg;
-  Serial.printf("Attempting connection with PCB %08X, ", (intptr_t)*msg->pcb_ptr);
-  Serial.print(IPAddress(msg->connect.addr));
-  Serial.printf(", port %d\n", msg->connect.port);
   msg->err = tcp_connect(*msg->pcb_ptr, msg->connect.addr, msg->connect.port, msg->connect.cb);
   return msg->err;
 }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -123,7 +123,7 @@ static lwip_tcp_event_packet_t *_alloc_event(lwip_tcp_event_t event, AsyncClient
     return nullptr;
   }
 
-  lwip_tcp_event_packet_t *e = (lwip_tcp_event_packet_t *)malloc(sizeof(lwip_tcp_event_packet_t));
+  auto *e = new (std::nothrow) lwip_tcp_event_packet_t{nullptr, event, client};
 
   if (!e) {
     // Allocation fail - abort client and give up
@@ -135,9 +135,6 @@ static lwip_tcp_event_packet_t *_alloc_event(lwip_tcp_event_t event, AsyncClient
     return nullptr;
   }
 
-  e->next = nullptr;
-  e->event = event;
-  e->client = client;
 #ifdef ASYNCTCP_VALIDATE_PCB
   e->pcb = pcb;
 #endif
@@ -151,7 +148,7 @@ static void _free_event(lwip_tcp_event_packet_t *evpkt) {
     // We must free the packet buffer
     pbuf_free(evpkt->recv.pb);
   }
-  free(evpkt);
+  delete evpkt;
 }
 
 // Global variables

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -251,8 +251,10 @@ protected:
   lwip_tcp_event_packet_t *_end_event;
   bool _needs_discard;
   unsigned _polls_pending;
-  struct pbuf *_recv_pending;
   uint16_t _sent_pending;
+#ifdef CONFIG_ASYNC_TCP_COALESCE_RECV
+  struct lwip_tcp_event_packet_t *_recv_pending;
+#endif
 
   AcConnectHandler _connect_cb;
   void *_connect_cb_arg;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -250,6 +250,9 @@ protected:
   tcp_pcb *_pcb;
   lwip_tcp_event_packet_t *_end_event;
   bool _needs_discard;
+  unsigned _polls_pending;
+  struct pbuf *_recv_pending;
+  uint16_t _sent_pending;
 
   AcConnectHandler _connect_cb;
   void *_connect_cb_arg;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -51,10 +51,6 @@ extern "C" {
 #define CONFIG_ASYNC_TCP_MAX_ACK_TIME 5000
 #endif
 
-#ifndef CONFIG_ASYNCTCP_HAS_INTRUSIVE_LIST
-#define CONFIG_ASYNCTCP_HAS_INTRUSIVE_LIST 1
-#endif
-
 class AsyncClient;
 
 #define ASYNC_WRITE_FLAG_COPY 0x01  // will allocate new buffer to hold the data while sending (else will hold reference to the data given)
@@ -276,13 +272,6 @@ protected:
   int8_t _recv(pbuf *pb, int8_t err);
   void _dns_found(struct ip_addr *ipaddr);
   int8_t _recved(size_t len);
-
-#ifdef CONFIG_ASYNC_TCP_CLIENT_LIST
-public:
-  AsyncClient *prev;
-  AsyncClient *next;
-  AsyncClient &operator+=(const AsyncClient &other);
-#endif
 };
 
 class AsyncServer {

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -95,6 +95,7 @@ public:
   bool connect(const char *host, uint16_t port);
   /**
      * @brief close connection
+     * @note will call onDisconnect callback
      *
      * @param now - ignored
      */
@@ -103,6 +104,13 @@ public:
   void stop() {
     close(false);
   };
+
+  /**
+     * @brief abort connection
+     * @note does NOT call onDisconnect callback!
+     *
+     * @return always returns ERR_ABRT
+     */
   int8_t abort();
   bool free();
 

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -269,7 +269,7 @@ protected:
   uint16_t _connect_port;
 
   friend class AsyncClient_detail;
-  bool _connect(ip_addr_t addr, uint16_t port);
+  bool _connect(const ip_addr_t &addr, uint16_t port);
   int8_t _close();
   int8_t _connected(int8_t err);
   void _error(int8_t err);

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -145,7 +145,7 @@ public:
   size_t write(const char *data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY);
 
   /**
-     * @brief add and enque data for sending
+     * @brief add and enqueue data for sending
      * @note treats data as null-terminated string
      *
      * @param data

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -81,8 +81,10 @@ public:
   AsyncClient(AsyncClient &&) = delete;
   AsyncClient &operator=(AsyncClient &&) = delete;
 
-  bool operator==(const AsyncClient &other);
-  bool operator!=(const AsyncClient &other) {
+  inline bool operator==(const AsyncClient &other) {
+    return _pcb == other._pcb;
+  }
+  inline bool operator!=(const AsyncClient &other) {
     return !(*this == other);
   }
 

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -73,6 +73,14 @@ public:
   AsyncClient(tcp_pcb *pcb = 0);
   ~AsyncClient();
 
+  // Noncopyable
+  AsyncClient(const AsyncClient &) = delete;
+  AsyncClient &operator=(const AsyncClient &) = delete;
+
+  // Nonmovable
+  AsyncClient(AsyncClient &&) = delete;
+  AsyncClient &operator=(AsyncClient &&) = delete;
+
   bool operator==(const AsyncClient &other);
   bool operator!=(const AsyncClient &other) {
     return !(*this == other);
@@ -280,6 +288,15 @@ public:
 #endif
   AsyncServer(uint16_t port);
   ~AsyncServer();
+
+  // Noncopyable
+  AsyncServer(const AsyncServer &) = delete;
+  AsyncServer &operator=(const AsyncServer &) = delete;
+
+  // Nonmovable
+  AsyncServer(AsyncServer &&) = delete;
+  AsyncServer &operator=(AsyncServer &&) = delete;
+
   void onClient(AcConnectHandler cb, void *arg);
   void begin();
   void end();

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -13,6 +13,7 @@
 #endif
 #include "lwip/ip6_addr.h"
 #include "lwip/ip_addr.h"
+#include <atomic>
 #include <functional>
 
 #ifndef LIBRETINY
@@ -250,8 +251,8 @@ protected:
   tcp_pcb *_pcb;
   lwip_tcp_event_packet_t *_end_event;
   bool _needs_discard;
-  unsigned _polls_pending;
-  uint16_t _sent_pending;
+  std::atomic<unsigned> _polls_pending;
+  std::atomic<uint16_t> _sent_pending;
 #ifdef CONFIG_ASYNC_TCP_COALESCE_RECV
   struct lwip_tcp_event_packet_t *_recv_pending;
 #endif

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -249,6 +249,7 @@ public:
 protected:
   tcp_pcb *_pcb;
   lwip_tcp_event_packet_t *_end_event;
+  bool _needs_discard;
 
   AcConnectHandler _connect_cb;
   void *_connect_cb_arg;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -73,8 +73,6 @@ public:
   AsyncClient(tcp_pcb *pcb = 0);
   ~AsyncClient();
 
-  AsyncClient &operator=(const AsyncClient &other);
-
   bool operator==(const AsyncClient &other);
   bool operator!=(const AsyncClient &other) {
     return !(*this == other);

--- a/src/simple_intrusive_list.h
+++ b/src/simple_intrusive_list.h
@@ -1,0 +1,106 @@
+// Simple intrusive list class
+
+template<typename T> class simple_intrusive_list {
+  static_assert(std::is_same<decltype(std::declval<T>().next), T *>::value, "Template type must have public 'T* next' member");
+
+private:
+  T *_head;
+  T **_tail;
+
+public:
+  // Static utility methods
+  static size_t list_size(T *chain) {
+    size_t count = 0;
+    for (auto c = chain; c != nullptr; c = c->next) {
+      ++count;
+    }
+    return count;
+  }
+
+  static void delete_list(T *chain) {
+    while (chain) {
+      auto t = chain;
+      chain = chain->next;
+      delete t;
+    }
+  }
+
+public:
+  // Object methods
+
+  simple_intrusive_list() : _head(nullptr), _tail(&_head) {}
+  ~simple_intrusive_list() {
+    clear();
+  }
+
+  // Noncopyable, nonmovable
+  simple_intrusive_list(const simple_intrusive_list<T> &) = delete;
+  simple_intrusive_list(simple_intrusive_list<T> &&) = delete;
+  simple_intrusive_list<T> &operator=(const simple_intrusive_list<T> &) = delete;
+  simple_intrusive_list<T> &operator=(simple_intrusive_list<T> &&) = delete;
+
+  void push_back(T *obj) {
+    if (obj) {
+      *_tail = obj;
+      _tail = &obj->next;
+    }
+  }
+
+  void push_front(T *obj) {
+    if (obj) {
+      if (_head == nullptr) {
+        _tail = &obj->next;
+      }
+      obj->next = _head;
+      _head = obj;
+    }
+  }
+
+  T *pop_front() {
+    auto rv = _head;
+    if (_head) {
+      if (_tail == &_head->next) {
+        _tail = &_head;
+      }
+      _head = _head->next;
+    }
+    return rv;
+  }
+
+  void clear() {
+    // Assumes all elements were allocated with "new"
+    delete_list(_head);
+    _head = nullptr;
+    _tail = &_head;
+  }
+
+  size_t size() const {
+    return list_size(_head);
+  }
+
+  T *remove_if(const std::function<bool(T &)> &condition) {
+    T *removed = nullptr;
+    auto **current_ptr = &_head;
+    while (*current_ptr != nullptr) {
+      auto *current = *current_ptr;
+      if (condition(*current)) {
+        *current_ptr = current->next;
+        if (current->next == nullptr) {
+          _tail = current_ptr;
+        }
+        current->next = removed;
+        removed = current;
+        // do not advance current_ptr
+      } else {
+        // advance current_ptr
+        current_ptr = &(*current_ptr)->next;
+      }
+    }
+
+    return removed;
+  }
+
+  T *begin() const {
+    return _head;
+  }
+};  // class simple_intrusive_list

--- a/src/simple_intrusive_list.h
+++ b/src/simple_intrusive_list.h
@@ -108,6 +108,17 @@ public:
     return _head;
   }
 
+  bool validate_tail() const {
+    if (_head == nullptr) {
+      return (_tail == &_head);
+    }
+    auto p = _head;
+    while (p->next != nullptr) {
+      p = p->next;
+    }
+    return _tail == &p->next;
+  }
+
 private:
   // Data members
   value_ptr_type _head;

--- a/src/simple_intrusive_list.h
+++ b/src/simple_intrusive_list.h
@@ -1,5 +1,7 @@
 // Simple intrusive list class
 
+#pragma once
+
 template<typename T> class simple_intrusive_list {
   static_assert(std::is_same<decltype(std::declval<T>().next), T *>::value, "Template type must have public 'T* next' member");
 


### PR DESCRIPTION
Replace the bounded queue with a linked list and "condvar" implementation, and replace the closed_slots system with double indirection via AsyncClient's own memory.  This allows the system to correctly handle cases where it is not possible to allocate a new event while guaranteeing that the client's `onDisconnect()` will be run to free up any other related resources.

Key changes:
- Replaces FreeRTOS fixed-size queue with a dynamic allocation list;
- Removes `CONFIG_ASYNC_TCP_QUEUE_SIZE` queue size limit;
- Makes AsyncClient's intrusive list support optional via `CONFIG_ASYNCTCP_HAS_INTRUSIVE_LIST`
- Replace the closed slot system with a double indirection on `AsyncClient`'s own `_pcb` member.  Once initialized, this member is written only by the LwIP thread, preventing most races; and the `AsyncClient` object itself is never deleted on the LwIP thread.
- Internal callbacks are made private

This draft rebases the changes from willmmiles/AsyncTCP:master to this development line.  As this project is moving faster than I can keep up with, in the interests of making this code available for review sooner, I have performed only minimal testing on this port.  It is likely there is a porting error somewhere.

Known issues as of this writing:
- `AsyncClient::operator=(const AsyncClient&)` assignment operator is removed.  The old code had implemented this operation with an unsafe partial move sematic, leaving the old object holding a dangling reference to the pcb.  It's not clear to me what should be done here - copies of AsyncClient are not generally meaningful.
- Poll coaelscing is not yet implemented.  This could be done with a list walk, as before, or via storing pending poll event pointers in the AsyncClient objects.
- Move construction and assignment is not yet implemented.  It will require careful interlocking with the LwIP and async threads.
- I'm about 85% confident there's still a race somewhere when an `AsyncClient` is addressed from a third task (eg. from an Arduino `loop()`, not LwIP or the async task).  The fact that LwIP reserves the right to invalidate tcp_pcbs on its thread at any time after `tcp_err` makes this extremely challenging to get both strictly correct and performant.  Core operations that pass to the LwIP thread are safe, but I think state reads (`state()`, `space()`, etc.) are still risky.
- If strict memory bounds are required, a soft queue size limit could be reimplemented, with the caveat that each client's `_end_event` can ignore the limit to ensure `onDisconnect` gets run.

Future work:
- `lwip_tcp_event_packet_t::dns` should be unbundled to a separate event object type from the rest of the `lwip_tcp_event_packet_t` variants.  It's easily twice the size of any of the others; this will reduce the memory footprint for normal operation.
- Event coaelscing could be considered for other types -- `recv` and `send` also permit sensible aggregation.
