### PR TITLE
fix(mem): Fix memory leak in _accept() functions when _accept is called with a null pcb

### DIFF
--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -246,6 +246,8 @@ public:
   }
 
 protected:
+  friend class AsyncServer;
+
   bool _connect(ip_addr_t addr, uint16_t port);
 
   tcp_pcb *_pcb;


### PR DESCRIPTION
Fix inspired by PR https://github.com/ESP32Async/AsyncTCP/pull/21 from @willmmiles

AsyncTCP had a memory leak when receiving too many requests, even if the queue length is increased (256 in my testing). The problem was in the handling of the _accept function which was not handling all the possible use cases.

To reproduce, in main branch, trigger 3 times:

`autocannon -c 32 -w 32 -a 96 -t 30 --renderStatusCodes  http://192.168.4.1`

You should see a log similar than this one:

[device-monitor-250207-213547.log](https://github.com/user-attachments/files/18713506/device-monitor-250207-213547.log)

In my case, starting at 

`Uptime:   2 s, requests:   0, Free heap: 236932`

Ending at:

`Uptime: 220 s, requests: 192, Free heap: 207624`

With this fix, you should see a log similar to this one:

[device-monitor-250207-222548.log](https://github.com/user-attachments/files/18713515/device-monitor-250207-222548.log)

`[165298][E][AsyncTCP.cpp:1659] _accept(): _accept failed: pcb is NULL`

This is the use case that was not handled before and was causing a leak 👍 