### PR TITLE
Directly reset callbacks without going through lwip functions (fix #30)

### DIFF
--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -239,6 +239,7 @@ public:
   static int8_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len);
   static int8_t _s_connected(void *arg, struct tcp_pcb *tpcb, int8_t err);
   static void _s_dns_found(const char *name, struct ip_addr *ipaddr, void *arg);
+  static void _tcp_error(void *arg, int8_t err);
 
   int8_t _recv(tcp_pcb *pcb, pbuf *pb, int8_t err);
   tcp_pcb *pcb() {


### PR DESCRIPTION
fix #30