### PR TITLE
Adapt library for compatibility with both ESP-IDF and Arduino framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ set(COMPONENT_ADD_INCLUDEDIRS
     "src"
 )
 
-set(COMPONENT_REQUIRES
-    "arduino-esp32"
-)
+# set(COMPONENT_REQUIRES
+#     # "arduino-esp32"
+# )
 
 register_component()
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,8 +1,8 @@
 description: "Async TCP Library for ESP32 Arduino"
 url: "https://github.com/ESP32Async/AsyncTCP"
 license: "LGPL-3.0-or-later"
-tags:
-  - arduino
+# tags:
+  # - arduino
 files:
   exclude:
     - "idf_component_examples/"
@@ -24,9 +24,9 @@ files:
     - "library.properties"
     - "platformio.ini"
     - "pre-commit.requirements.txt"
-dependencies:
-  espressif/arduino-esp32:
-    version: "^3.1.1"
-    require: public
-examples:
-  - path: ./idf_component_examples/client
+# dependencies:
+#   espressif/arduino-esp32:
+#     version: "^3.1.1"
+#     require: public
+# examples:
+#   - path: ./idf_component_examples/client


### PR DESCRIPTION
Added preprocessor macros to detect and separate ESP-IDF vs Arduino.

I've done some minor code refactor to enable the use of the library without any dependency on behalf of Arduino framework, but keeping it functional with it if the user intends to make use of Arduino.

The NO use of the Arduino framework is basically done by the following macro. Maybe it could be done in some other way:
```
#if defined(ESP_PLATFORM) && (ESP_IDF_VERSION_MAJOR >= 5) && !defined(ARDUINO)
  #define USING_PURE_ESP_IDF_V5_PLUS
```
The idea behind this, was to preserved as much code as possible intact, and just change what was necessary to make it work in esp-idf.

I've created some other macros for handling Arduino log_x and the use of millis():
```
#if defined(USING_PURE_ESP_IDF_V5_PLUS)
  #define log_e(...) ESP_LOGE(__FILE__, __VA_ARGS__)
  #define log_w(...) ESP_LOGW(__FILE__, __VA_ARGS__)
  #define log_i(...) ESP_LOGI(__FILE__, __VA_ARGS__)
  #define log_d(...) ESP_LOGD(__FILE__, __VA_ARGS__)
  #define log_v(...) ESP_LOGV(__FILE__, __VA_ARGS__)

  #define millis() (esp_timer_get_time() / 1000ULL)
#else
  #include "Arduino.h"
  #if(ESP_IDF_VERSION_MAJOR >= 5)
    #include <NetworkInterface.h>
  #endif
#endif

```

Again, this is a proof of concept, and surely could be done more elegantly.
For what is worth, what triggered this effort was to find out that there is no proper maintained async web server library for esp-idf (!Arduino) and it seemed the right way to start. The original discussion can be found [here](https://github.com/hoeken/PsychicHttp/issues/217)

I hope we can merge this so as to continue the same work with ESPAsyncWebServer.