### PR TITLE
AsyncTCP without Arduino (ESP-IDF only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ set(COMPONENT_ADD_INCLUDEDIRS
     "src"
 )
 
-set(COMPONENT_REQUIRES
-    "arduino-esp32"
-)
-
 register_component()
 
 target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,8 +1,6 @@
 description: "Async TCP Library for ESP32 Arduino"
 url: "https://github.com/ESP32Async/AsyncTCP"
 license: "LGPL-3.0-or-later"
-tags:
-  - arduino
 files:
   exclude:
     - "idf_component_examples/"
@@ -24,9 +22,5 @@ files:
     - "library.properties"
     - "platformio.ini"
     - "pre-commit.requirements.txt"
-dependencies:
-  espressif/arduino-esp32:
-    version: "^3.1.1"
-    require: public
 examples:
   - path: ./idf_component_examples/client

--- a/idf_component_examples/client/main/CMakeLists.txt
+++ b/idf_component_examples/client/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "main.cpp"
-                    INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "."
+                       PRIV_REQUIRES esp_timer)

--- a/idf_component_examples/client/main/idf_component.yml
+++ b/idf_component_examples/client/main/idf_component.yml
@@ -4,3 +4,6 @@ dependencies:
     version: "*"
     override_path: "../../../"
     pre_release: true
+  espressif/arduino-esp32:
+    version: ">=3.0.5"
+    require: public


### PR DESCRIPTION
This PR complements the work from @gnalbandian in PR https://github.com/ESP32Async/AsyncTCP/pull/47

- Add ESP-IDf related api even on Arduino since compatible
- Treat Arduino API as delegates on esp-idf layer