### PR TITLE
Code cleanup prior to queue replacement

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -732,7 +732,7 @@ static tcp_pcb *_tcp_listen_with_backlog(tcp_pcb *pcb, uint8_t backlog) {
 AsyncClient::AsyncClient(tcp_pcb *pcb)
   : _connect_cb(0), _connect_cb_arg(0), _discard_cb(0), _discard_cb_arg(0), _sent_cb(0), _sent_cb_arg(0), _error_cb(0), _error_cb_arg(0), _recv_cb(0),
     _recv_cb_arg(0), _pb_cb(0), _pb_cb_arg(0), _timeout_cb(0), _timeout_cb_arg(0), _poll_cb(0), _poll_cb_arg(0), _ack_pcb(true), _tx_last_packet(0),
-    _rx_timeout(0), _rx_last_ack(0), _ack_timeout(CONFIG_ASYNC_TCP_MAX_ACK_TIME), _connect_port(0), prev(NULL), next(NULL) {
+    _rx_timeout(0), _rx_last_ack(0), _ack_timeout(CONFIG_ASYNC_TCP_MAX_ACK_TIME), _connect_port(0) {
   _pcb = pcb;
   _closed_slot = INVALID_CLOSED_SLOT;
   if (_pcb) {
@@ -779,21 +779,6 @@ AsyncClient &AsyncClient::operator=(const AsyncClient &other) {
 
 bool AsyncClient::operator==(const AsyncClient &other) const {
   return _pcb == other._pcb;
-}
-
-AsyncClient &AsyncClient::operator+=(const AsyncClient &other) {
-  if (next == NULL) {
-    next = (AsyncClient *)(&other);
-    next->prev = this;
-  } else {
-    AsyncClient *c = next;
-    while (c->next != NULL) {
-      c = c->next;
-    }
-    c->next = (AsyncClient *)(&other);
-    c->next->prev = c;
-  }
-  return *this;
 }
 
 /*

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -759,24 +759,6 @@ AsyncClient::~AsyncClient() {
  * Operators
  * */
 
-AsyncClient &AsyncClient::operator=(const AsyncClient &other) {
-  if (_pcb) {
-    _close();
-  }
-
-  _pcb = other._pcb;
-  _closed_slot = other._closed_slot;
-  if (_pcb) {
-    _rx_last_packet = millis();
-    tcp_arg(_pcb, this);
-    tcp_recv(_pcb, &_tcp_recv);
-    tcp_sent(_pcb, &_tcp_sent);
-    tcp_err(_pcb, &_tcp_error);
-    tcp_poll(_pcb, &_tcp_poll, CONFIG_ASYNC_TCP_POLL_TIMER);
-  }
-  return *this;
-}
-
 bool AsyncClient::operator==(const AsyncClient &other) const {
   return _pcb == other._pcb;
 }

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -74,6 +74,7 @@ typedef std::function<void(void *, AsyncClient *, uint32_t time)> AcTimeoutHandl
 
 struct tcp_pcb;
 struct ip_addr;
+class AsyncTCP_detail;
 
 class AsyncClient {
 public:
@@ -255,23 +256,13 @@ public:
   static const char *errorToString(int8_t error);
   const char *stateToString() const;
 
-  // internal callbacks - Do NOT call any of the functions below in user code!
-  static int8_t _s_poll(void *arg, struct tcp_pcb *tpcb);
-  static int8_t _s_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *pb, int8_t err);
-  static int8_t _s_fin(void *arg, struct tcp_pcb *tpcb, int8_t err);
-  static int8_t _s_lwip_fin(void *arg, struct tcp_pcb *tpcb, int8_t err);
-  static void _s_error(void *arg, int8_t err);
-  static int8_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len);
-  static int8_t _s_connected(void *arg, struct tcp_pcb *tpcb, int8_t err);
-  static void _s_dns_found(const char *name, struct ip_addr *ipaddr, void *arg);
-  static void _tcp_error(void *arg, int8_t err);
-
   int8_t _recv(tcp_pcb *pcb, pbuf *pb, int8_t err);
   tcp_pcb *pcb() {
     return _pcb;
   }
 
 protected:
+  friend class AsyncTCP_detail;
   friend class AsyncServer;
 
   tcp_pcb *_pcb;
@@ -333,11 +324,9 @@ public:
   bool getNoDelay() const;
   uint8_t status() const;
 
-  // Do not use any of the functions below!
-  static int8_t _s_accept(void *arg, tcp_pcb *newpcb, int8_t err);
-  static int8_t _s_accepted(void *arg, AsyncClient *client);
-
 protected:
+  friend class AsyncTCP_detail;
+
   uint16_t _port;
   ip_addr_t _addr;
   bool _noDelay;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -81,7 +81,6 @@ public:
   ~AsyncClient();
 
   AsyncClient &operator=(const AsyncClient &other);
-  AsyncClient &operator+=(const AsyncClient &other);
 
   bool operator==(const AsyncClient &other) const;
 
@@ -308,10 +307,6 @@ protected:
   int8_t _fin(tcp_pcb *pcb, int8_t err);
   int8_t _lwip_fin(tcp_pcb *pcb, int8_t err);
   void _dns_found(struct ip_addr *ipaddr);
-
-public:
-  AsyncClient *prev;
-  AsyncClient *next;
 };
 
 class AsyncServer {

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -80,7 +80,13 @@ public:
   AsyncClient(tcp_pcb *pcb = 0);
   ~AsyncClient();
 
-  AsyncClient &operator=(const AsyncClient &other);
+  // Noncopyable
+  AsyncClient(const AsyncClient &) = delete;
+  AsyncClient &operator=(const AsyncClient &) = delete;
+
+  // Nonmovable
+  AsyncClient(AsyncClient &&) = delete;
+  AsyncClient &operator=(AsyncClient &&) = delete;
 
   bool operator==(const AsyncClient &other) const;
 


### PR DESCRIPTION
This is the first part of a replacment series for #21, consisting of removing unsafe interfaces and some internal cleanup prior to the queue structure change.

- Remove the intrusive list from AsyncClient
- Remove the unsafe copy constructor from AsyncClient
- Use a recursion-safe guard class over the LwIP mutex
- Remove private callbacks from public headers
- Strengthen client pointer typing in lwip_tcp_event_packet_t