### PR TITLE
Add AsyncTCP_stats class with a method to get the task high water mark

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1633,3 +1633,7 @@ uint8_t AsyncServer::status() const {
   }
   return _pcb->state;
 }
+
+UBaseType_t AsyncTCP_stats::getHighWaterMark() {
+  return uxTaskGetStackHighWaterMark(_async_service_task_handle);
+}

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -338,4 +338,9 @@ protected:
   int8_t _accepted(AsyncClient *client);
 };
 
+class AsyncTCP_stats {
+public:
+  static UBaseType_t getHighWaterMark();
+};
+
 #endif /* ASYNCTCP_H_ */


### PR DESCRIPTION
This is useful for dialing the memory required for handling the Async TCP task and minimizing resource consumption. 