### PR TITLE
Add LibreTiny support

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -3,6 +3,7 @@
 
 #include "AsyncTCP.h"
 
+#ifdef ESP32
 #include <esp_log.h>
 
 #ifdef ARDUINO
@@ -21,6 +22,11 @@
 static unsigned long millis() {
   return (unsigned long)(esp_timer_get_time() / 1000ULL);
 }
+#endif
+#endif
+
+#ifdef LIBRETINY
+#include <Arduino.h>
 #endif
 
 extern "C" {

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -3,7 +3,7 @@
 
 #include "AsyncTCP.h"
 
-#ifdef ESP32
+#ifndef LIBRETINY
 #include <esp_log.h>
 
 #ifdef ARDUINO

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -7,7 +7,11 @@
 #include "AsyncTCPVersion.h"
 #define ASYNCTCP_FORK_ESP32Async
 
+#ifdef ESP32
 #include <esp_idf_version.h>
+#else
+#define ESP_IDF_VERSION_MAJOR (0)
+#endif
 
 #ifdef ARDUINO
 #include "IPAddress.h"
@@ -29,9 +33,11 @@ extern "C" {
 #else
 extern "C" {
 #include <lwip/pbuf.h>
+#include <FreeRTOS.h>
 #include <semphr.h>
 }
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1  // any available core
+#define CONFIG_FREERTOS_UNICORE 1
 #endif
 
 // If core is not defined, then we are running in Arduino or PIO

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -7,10 +7,10 @@
 #include "AsyncTCPVersion.h"
 #define ASYNCTCP_FORK_ESP32Async
 
-#ifdef ESP32
-#include <esp_idf_version.h>
-#else
+#ifdef LIBRETINY
 #define ESP_IDF_VERSION_MAJOR (0)
+#else
+#include <esp_idf_version.h>
 #endif
 
 #ifdef ARDUINO


### PR DESCRIPTION
This PR adds support for LibreTiny to AsyncTCP.
Aside from several new `#ifdef LIBRETINY` conditionals, it was required to add support for non-IPv6 lwIP.
Context: https://github.com/ESP32Async/ESPAsyncWebServer/pull/187