### PR TITLE
Restore support for LibreTiny RTL8710BN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
 
           - env: ci-arduino-libretiny
             board: generic-bk7231n-qfn32-tuya
-          # - env: ci-arduino-libretiny
-          #   board: generic-rtl8710bn-2mb-788k
+          - env: ci-arduino-libretiny
+            board: generic-rtl8710bn-2mb-788k
 
     steps:
       - name: Checkout

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,9 @@ build_flags =
   -Wno-unused-parameter
   -Wno-unused-variable
   -Wno-missing-field-initializers
+; use FreeRTOS v9.0.0 for RTL8710BN
+; (BK7231 already uses it)
+custom_versions.freertos = 9.0.0
 
 ;  CI
 
@@ -62,3 +65,4 @@ build_flags =
   -Wno-unused-parameter
   -Wno-unused-variable
   -Wno-missing-field-initializers
+custom_versions.freertos = 9.0.0


### PR DESCRIPTION
This PR uses FreeRTOS v9.0.0 on LibreTiny, making it compatible with both BK7231 and RTL8710BN (and also LN882).

Until LibreTiny migrates to v9.0.0 by default, this PlatformIO option is needed.