### PR TITLE
Fix esp-idf component example build

### DIFF
--- a/idf_component_examples/client/main/idf_component.yml
+++ b/idf_component_examples/client/main/idf_component.yml
@@ -5,5 +5,5 @@ dependencies:
     override_path: "../../../"
     pre_release: true
   espressif/arduino-esp32:
-    version: ">=3.0.5"
+    version: ">=3.2.0"
     require: public


### PR DESCRIPTION
Arduino core version was too low for esp-idf versions >= 5.4 due to API changes.