### PR TITLE
fixed NetworkInterface.h include for ESPHOME

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -10,7 +10,7 @@
 #ifdef ARDUINO
 #include <esp32-hal.h>
 #include <esp32-hal-log.h>
-#if (ESP_IDF_VERSION_MAJOR >= 5)
+#if (ESP_IDF_VERSION_MAJOR >= 5) && !defined(ARDUINO)
 #include <NetworkInterface.h>
 #endif
 #else


### PR DESCRIPTION
I had issues in ESPHome because the newer arduino core is also based on ESP IDF 5.x.

Because of that it tries to find the NetworkInterface.h file in arduino core what is not possible.

This will not include the file if arduino is in use.

regards,
Manuel