### PR TITLE
Error/closing stability

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -484,7 +484,8 @@ void AsyncTCP_detail::tcp_error(void *arg, int8_t err) {
   // ets_printf("+E: 0x%08x\n", arg);
   AsyncClient *client = reinterpret_cast<AsyncClient *>(arg);
   if (client && client->_pcb) {
-    _reset_tcp_callbacks(client->_pcb, client);
+    // The pcb has already been freed by LwIP; do not attempt to clear the callbacks!
+    _remove_events_for_client(client);
     client->_pcb = nullptr;
   }
 


### PR DESCRIPTION
I found a couple of logic errors in the error event handling:

- `_reset_tcp_callbacks()` must not be called in the `tcp_err()` callback, as the pcb has already been `free()`d by LwIP.  This was writing zeros to memory potentially already recycled on the other core.
- There was a potential race between a client closing or aborting a connection, and a FIN or ERROR event:
  1. Client decides to destruct an `AsyncClient` on async task - say, after completing a send -- which calls `AsyncClient::close()`.  `_pcb` checks pass; `_tcp_close_api()` is queued on LwIP task.
  2. LwIP task process FIN or ERROR callback for that client.  `AsyncClient::_pcb` is nulled out, and the event is queued.
  3. LwIP task services `_tcp_close_api()`.  `*msg->pcb` is null, so no action occurs.  Event remains queued.
  4. `AsyncClient::~AsyncClient()` proceeds, oblivious to queued event.
  5. FIN/ERROR event is processed for now-destroyed AsyncClient.   Kaboom!  (Common pattern was that old client memory is still valid, so the dispose callback got run again, double-`free()`ing the client.)
