### PR TITLE
discard callback must be called on abort()

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -925,6 +925,10 @@ int8_t AsyncClient::abort() {
     _tcp_abort(&_pcb, this);
     // _pcb is now NULL
   }
+  if (_discard_cb) {
+    // _pcb was closed here
+    _discard_cb(_discard_cb_arg, this);
+  }
   return ERR_ABRT;
 }
 


### PR DESCRIPTION
This PR fixes a bug introduced in PR #79.

discarded callback must also be called when abort() is called.

Ref: https://github.com/ESP32Async/ESPAsyncWebServer/discussions/253