### PR TITLE
Deprecate the old close(bool) call

### DIFF
--- a/examples/Client/Client.ino
+++ b/examples/Client/Client.ino
@@ -31,7 +31,7 @@ void makeRequest() {
 
   client->onError([](void *arg, AsyncClient *client, int8_t error) {
     Serial.printf("** error occurred %s \n", client->errorToString(error));
-    client->close(true);
+    client->close();
     delete client;
   });
 
@@ -41,7 +41,7 @@ void makeRequest() {
 
     client->onDisconnect([](void *arg, AsyncClient *client) {
       Serial.printf("** client has been disconnected: %" PRIu16 "\n", client->localPort());
-      client->close(true);
+      client->close();
       delete client;
 
       permits++;

--- a/idf_component_examples/client/main/main.cpp
+++ b/idf_component_examples/client/main/main.cpp
@@ -28,7 +28,7 @@ void makeRequest() {
 
   client->onError([](void *arg, AsyncClient *client, int8_t error) {
     Serial.printf("** error occurred %s \n", client->errorToString(error));
-    client->close(true);
+    client->close();
     delete client;
     client_running = false;
   });
@@ -38,7 +38,7 @@ void makeRequest() {
 
     client->onDisconnect([](void *arg, AsyncClient *client) {
       Serial.printf("** client has been disconnected: %" PRIu16 "\n", client->localPort());
-      client->close(true);
+      client->close();
       delete client;
       client_running = false;
     });

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -921,7 +921,7 @@ bool AsyncClient::connect(const char *host, uint16_t port) {
   return false;
 }
 
-void AsyncClient::close(bool now) {
+void AsyncClient::close() {
   if (_pcb) {
     _tcp_recved(&_pcb, _rx_ack_len);
   }

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -99,16 +99,26 @@ public:
 #endif
 #endif
   bool connect(const char *host, uint16_t port);
+
   /**
      * @brief close connection
      *
      * @param now - ignored
      */
-  void close(bool now = false);
-  // same as close()
+  [[deprecated("Use AsyncClient::close() instead")]]
+  void close(bool now) {
+    close();
+  }
+  [[deprecated("Use AsyncClient::close() instead")]]
   void stop() {
-    close(false);
+    close();
   };
+
+  /**
+     * @brief close connection
+     */
+  void close();
+
   int8_t abort();
   bool free();
 


### PR DESCRIPTION
I suspect close(bool) was kept for drop-in replacement with espasynctcp for 8266...