### PR TITLE
fix(queue) use-after-free in abort() path

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -676,14 +676,20 @@ static esp_err_t _tcp_close(tcp_pcb **pcb, AsyncClient *client) {
 }
 
 static err_t _tcp_abort_api(struct tcpip_api_call_data *api_call_msg) {
-  // Like close(), we must ensure that the queue is cleared
+  // Like close(), we must ensure that the queue is cleared of any events referencing the AsyncClient.
+  // ERR_ABRT: the pcb was aborted.
+  // ERR_OK:   the pcb was already gone, but a queued error event was purged, so the
+  //           caller must still run the discard callback (dispose needs to run).
+  // ERR_CONN: nothing to do (pcb already null and no queued events).
   tcp_api_call_t *msg = (tcp_api_call_t *)api_call_msg;
   if (*msg->pcb) {
+    _reset_tcp_callbacks(*msg->pcb, msg->close);
     tcp_abort(*msg->pcb);
     *msg->pcb = nullptr;  // PCB is now the property of LwIP
     msg->err = ERR_ABRT;
   } else {
-    msg->err = ERR_CONN;
+    // Ensure there is not an error event queued for this client
+    msg->err = _remove_events_for_client(msg->close) ? ERR_OK : ERR_CONN;
   }
   return msg->err;
 }
@@ -939,8 +945,15 @@ void AsyncClient::close() {
 }
 
 int8_t AsyncClient::abort() {
-  return _tcp_abort(&_pcb, this);
+  int8_t err = _tcp_abort(&_pcb, this);
   // _pcb is now NULL
+  // LwIP invokes the error callback when abort is issued; preserve this semantic.
+  // This will also trigger the dispose callback.
+  // If the pcb was previously invalidated by some other queued error, we've discarded that value; so we always send ERR_ABRT.
+  if (err != ERR_CONN) {
+    _error(ERR_ABRT);
+  }
+  return err;
 }
 
 size_t AsyncClient::space() const {


### PR DESCRIPTION
If aborting in WebSocket (torm frame), we must also purge the queue and reset callbacks

AsyncClient::_error(-13) execures with a  LWIP_TCP_ERROR event still present in the queue but client was dereferenced before

Crash that was occurring:

First  one seen:

```
[ 91238][V][AsyncTCP.cpp:1125] _poll(): onPoll took 8756 us
[ 91245][V][AsyncTCP.cpp:340] _async_service_task(): handle_async_event took 15160 us
[ 91252][V][AsyncWebSocket.cpp:608] _onError(): [/ws][1] ERROR -13
[ 91258][V][AsyncTCP.cpp:1033] _error(): onError took 6115 us
Guru Meditation Error: Core  1 panic'ed (IllegalInstruction). Exception was unhandled.
Core  1 register dump:
PC      : 0x7ec0eda1  PS      : 0x00060730  A0      : 0x001ad0f4  A1      : 0x3ffd20e0  
A2      : 0x3ffd2bac  A3      : 0xc00a8962  A4      : 0x3ffd2b94  A5      : 0x00000409  
A6      : 0x400d6866  A7      : 0x3ffd20cc  A8      : 0x800d64ae  A9      : 0x3ffd20d0  
A10     : 0x3ffd2bac  A11     : 0x00000032  A12     : 0x3ffd20e8  A13     : 0x00000040  
A14     : 0x3ffd20e2  A15     : 0x3ffc3c7d  SAR     : 0x00000001  EXCCAUSE: 0x00000000  
EXCVADDR: 0x00000000  LBEG    : 0x40083439  LEND    : 0x40083441  LCOUNT  : 0x00000027  
Backtrace: 0x7ec0ed9e:0x3ffd20e0 |<-CORRUPTED
ELF file SHA256: 5255f2a65
Rebooting...
```

Second one:

<img width="948" height="990" alt="image" src="https://github.com/user-attachments/assets/5a954fd4-b3ea-4075-8b26-d149bd468fea" />
